### PR TITLE
Mark mclock parameter of update_media_clock as const

### DIFF
--- a/module_avb_media_clock/src/media_clock_internal.h
+++ b/module_avb_media_clock/src/media_clock_internal.h
@@ -35,7 +35,7 @@ void init_media_clock_recovery(chanend ptp_svr,
 
 unsigned int update_media_clock(chanend ptp_svr, 
                                 int clock_index,
-                                REFERENCE_PARAM(media_clock_t, mclock),
+                                REFERENCE_PARAM(const media_clock_t, mclock),
                                 unsigned int t2,
                                 int period);
 

--- a/module_avb_media_clock/src/media_clock_support.c
+++ b/module_avb_media_clock/src/media_clock_support.c
@@ -141,7 +141,7 @@ void inform_media_clock_of_lock(int clock_index) {
 
 unsigned int update_media_clock(chanend ptp_svr,
 								int clock_index,
-								media_clock_t *mclock,
+								const media_clock_t *mclock,
 								unsigned int t2,
 								int period0) {
 	clock_info_t *clock_info = &clock_states[clock_index];


### PR DESCRIPTION
media_clock_server.c contains the following call:

media_clocks[i].wordLength =
  update_media_clock(ptp_svr, i, media_clocks[i], clk_time,
                     CLOCK_RECOVERY_PERIOD);

Previously media_clocks would conservatively be consider as written by the
RHS since it is passed by non const reference. It is also written on the
LHS of the assignment. This is invalid according to the XC spec.
The 11.11.0 tools don't spot this but future versions will.
